### PR TITLE
Show relevant questionnaires on click

### DIFF
--- a/android/mwcore/src/main/java/org/smartregister/fhircore/mwcore/ui/patient/details/ClientDetailsTab.kt
+++ b/android/mwcore/src/main/java/org/smartregister/fhircore/mwcore/ui/patient/details/ClientDetailsTab.kt
@@ -35,6 +35,7 @@ import org.smartregister.fhircore.engine.ui.register.RegisterViewModel
 import org.smartregister.fhircore.mwcore.R
 import org.smartregister.fhircore.mwcore.data.patient.model.genderFull
 import org.smartregister.fhircore.mwcore.util.MwCoreConfigClassification
+import org.smartregister.fhircore.mwcore.util.RegisterType.CLIENT_ID
 
 
 data class TabItem(
@@ -46,7 +47,7 @@ data class TabItem(
 
 
 @Composable
-fun DemographicsTab(questPatientDetailViewModel: QuestPatientDetailViewModel, configurationRegistry: ConfigurationRegistry) {
+fun DemographicsTab(questPatientDetailViewModel: QuestPatientDetailViewModel, configurationRegistry: ConfigurationRegistry, patientType: String) {
     val context = LocalContext.current
 
     val patientItem by questPatientDetailViewModel.patientItem.observeAsState(null)
@@ -86,7 +87,6 @@ fun DemographicsTab(questPatientDetailViewModel: QuestPatientDetailViewModel, co
                     Spacer(modifier = Modifier.size(10.dp))
                     Text(text = "Guardian", style = MaterialTheme.typography.h6)
 
-
                     Text(text = "Name: Janet Dzimbiri")
                     Text(text = "Gender: Female")
                     Text(text = "Relationship to client: Aunt")
@@ -106,54 +106,56 @@ fun DemographicsTab(questPatientDetailViewModel: QuestPatientDetailViewModel, co
                     Text(text = "TB History: Currently on treatment")
                     Text(text = "Regimen: 4A")
                     Text(text = "ART start date: 06/05/2018")
-
                 }
             }
-
 
         Row(
             Modifier
                 .fillMaxWidth()
+                .padding(bottom = 8.dp)
                 .wrapContentHeight(),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
             ExtendedFloatingActionButton(
-                onClick = {
-
-                    startActivity(
-                        context,
-                        Intent(context, QuestionnaireActivity::class.java)
-                            .putExtras(
-                                QuestionnaireActivity.intentArgs(
-                                    clientIdentifier = patientItem?.id,
-                                    formName = getRegistrationForm(configurationRegistry),
-                                    QuestionnaireType.EDIT
-                                )
-                            ), null
-                    )
-
-//                patientItem?.let { editPatient(it.id) }
-
-                },
-                icon = {
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_plus),
-                        contentDescription = "add guardian icon"
-                    )
-                },
+                onClick = { onEditDetailsClicked(context, patientItem?.id, configurationRegistry, patientType) },
                 modifier = Modifier.height(60.dp),
                 backgroundColor = MaterialTheme.colors.primary,
-                text = { Text("ADD GUARDIAN", fontSize = 16.sp) })
+                text = { Text("EDIT DETAILS", fontSize = 16.sp) },
+                icon = {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_edit),
+                        contentDescription = "edit icon"
+                    )
+                })
         }
-
     }
 }
 
+fun onEditDetailsClicked(context: Context, patientID: String?, configurationRegistry: ConfigurationRegistry, patientType: String) {
+    startActivity(
+        context,
+        Intent(context, QuestionnaireActivity::class.java)
+            .putExtras(
+                QuestionnaireActivity.intentArgs(
+                    clientIdentifier = patientID,
+                    formName = getRegistrationForm(configurationRegistry, patientType),
+                    QuestionnaireType.EDIT
+                )
+            ), null
+    )
+}
 
-fun getRegistrationForm(configurationRegistry: ConfigurationRegistry): String {
+fun getRegistrationForm(configurationRegistry: ConfigurationRegistry, patientType: String): String {
+    if (patientType == CLIENT_ID) {
+        return configurationRegistry.retrieveConfiguration<RegisterViewConfiguration>(
+            configClassification = MwCoreConfigClassification.PATIENT_REGISTER_CLIENT
+        )
+            .registrationForm
+    }
+
     return configurationRegistry.retrieveConfiguration<RegisterViewConfiguration>(
-        configClassification = MwCoreConfigClassification.PATIENT_REGISTER_CLIENT
+        configClassification = MwCoreConfigClassification.PATIENT_REGISTER_EXPOSED_INFANT
     )
         .registrationForm
 }

--- a/android/mwcore/src/main/java/org/smartregister/fhircore/mwcore/util/RegisterUtils.kt
+++ b/android/mwcore/src/main/java/org/smartregister/fhircore/mwcore/util/RegisterUtils.kt
@@ -26,7 +26,6 @@ import org.hl7.fhir.r4.model.UriType
 object RegisterType {
   const val CLIENT_ID = "patient_client"
   const val EXPOSED_INFANT_ID = "patient_exposed_infant"
-
 }
 
 const val REGISTER_CONFIG_FILE = "register_configurations.json"

--- a/android/mwcore/src/main/res/drawable/ic_edit.xml
+++ b/android/mwcore/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/android/mwcore/src/main/res/values/strings.xml
+++ b/android/mwcore/src/main/res/values/strings.xml
@@ -26,7 +26,5 @@
     <string name="no_test_results_found">No test results found</string>
     <string name="patient_test_results">TEST RESULTS</string>
     <string name="patient_type"> Patient_Type</string>
-    <string name="adult_patient">Client</string>
-    <string name="exposed_patient">Exposed</string>
 
 </resources>


### PR DESCRIPTION
In the view patient page:
- Changed 'add guardian' button to 'edit details' button
- Open relevant questionnaire when edit details is clicked within the view patient page for a client
- Open relevant questionnaire when edit details is clicked within the view patient page for an exposed infant
- Open relevant questionnaire when add guardian is clicked in the menu items of the view patient page
- Open relevant questionnaire when enter DBS results is clicked in the menu items of the view patient page for an exposed infant
- Open relevant questionnaire when enter viral load results is clicked in the menu items of the view patient page for a client